### PR TITLE
Quoted paths

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -68,7 +68,7 @@ export default class PythonScripterPlugin extends Plugin {
 							if (local_current_file_path === undefined) {
 								local_current_file_path = "";
 							}
-							exec(`python ${filePath} ${basePath} \"${local_current_file_path}\"`, {cwd: this.pythonDirectory}, (error: any, stdout: any, stderr: any) => {
+							exec(`python \"${filePath}\" \"${basePath}\" \"${local_current_file_path}\"`, {cwd: this.pythonDirectory}, (error: any, stdout: any, stderr: any) => {
 								if (error) {
 									new Notice(`Error executing script ${filePath}: ${error}`);
 									return;
@@ -82,7 +82,7 @@ export default class PythonScripterPlugin extends Plugin {
 							if (local_current_file_path === undefined) {
 								local_current_file_path = "";
 							}
-							exec(`python ${path.join(filePath, "src", "main.py")} ${basePath} \"${local_current_file_path}\"`, {cwd: dir}, (error: any, stdout: any, stderr: any) => {
+							exec(`python \"${path.join(filePath, "src", "main.py")}\" \"${basePath}\" \"${local_current_file_path}\"`, {cwd: dir}, (error: any, stdout: any, stderr: any) => {
 								if (error) {
 									new Notice(`Error executing folder program: ${error}`);
 									return;


### PR DESCRIPTION
By encapsulating the python script path and the Obsidian directory path, the plugin supports people who have their Obsidian directory descended from folders with spaces at no extra cost