### PR TITLE
Added 'Run on Last File' Feature

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -7,11 +7,13 @@ import { exec } from 'child_process';
 interface PythonScripterSettings {
 	pythonPath: string;
 	pythonExe: string;
+	useLastFile: boolean;
 }
 
 const DEFAULT_SETTINGS: PythonScripterSettings = {
 	pythonPath: "",
-	pythonExe: ""
+	pythonExe: "",
+	useLastFile: false
 }
 
 export default class PythonScripterPlugin extends Plugin {
@@ -71,6 +73,9 @@ export default class PythonScripterPlugin extends Plugin {
 						}
 						if (stats.isFile()) {
 							var  local_current_file_path = this.app.workspace.activeEditor?.file?.path;
+							if (this.settings.useLastFile) {
+								local_current_file_path = this.app.workspace.lastActiveFile?.path;
+							}
 							if (local_current_file_path === undefined) {
 								local_current_file_path = "";
 							}
@@ -155,6 +160,15 @@ class PythonScripterSettingTab extends PluginSettingTab {
 				.setValue(this.plugin.settings.pythonExe)
 				.onChange(async (value) => {
 					this.plugin.settings.pythonExe = value;
+					await this.plugin.saveSettings();
+				}));
+		new Setting(containerEl)
+			.setName('Use Last File')
+			.setDesc('Run the script on the last file that was opened. This make it possible to run it on other file types e.g. pdf.')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.useLastFile)
+				.onChange(async (value) => {
+					this.plugin.settings.useLastFile = value;
 					await this.plugin.saveSettings();
 				}));
 	}


### PR DESCRIPTION
Body: This PR introduces a new feature that allows users to run Python scripts on the last active file in the workspace. This is particularly useful for workflows that involve other files than md.

Added a new setting useLastFile that, when enabled, will cause scripts to be run on the last active file instead of the current active file.